### PR TITLE
Use readlink when changing to Workcraft dir

### DIFF
--- a/linux/workcraft
+++ b/linux/workcraft
@@ -4,7 +4,7 @@
 CURRENT_DIR="$PWD"
 
 # Change to Workcraft home directory and put it into the WORKCRAFT_HOME variable
-cd "$(dirname "$0")"
+cd "$(dirname "$(readlink -f $0)")"
 WORKCRAFT_HOME="$PWD"
 
 # Set the JVM executable in JAVA_BIN variable (if not defined yet)


### PR DESCRIPTION
Enables Workcraft to be started correctly from a symlink.

Passes CI. Coverage can be increased by also starting Workcraft from a symlink from a different directory in `ci/exec`.