### PR TITLE
Add desktop and MIME XML files for Linux

### DIFF
--- a/linux/workcraft.desktop
+++ b/linux/workcraft.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=Workcraft
+Comment=A framework for interpreted graph models including Petri nets and STGs
+Exec=workcraft
+Icon=workcraft
+Terminal=false
+StartupNotify=false
+Categories=Application;
+MimeType=application/x-workcraft;

--- a/linux/workcraft.xml
+++ b/linux/workcraft.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mime-info xmlns="http://www.freedesktop.org/standards/shared-mime-info">
+    <mime-type type="application/x-workcraft">
+        <comment>Workcraft Work File</comment>
+        <sub-class-of type="application/zip"/>
+        <icon name="application-x-workcraft"/>
+        <glob-deleteall/>
+        <glob pattern="*.work"/>
+    </mime-type>
+</mime-info>


### PR DESCRIPTION
The files allow visibility in applications menus and easy opening of `.work` files from file browsers. The files aren't required by Workcraft itself and are currently used only in the AUR package (https://aur.archlinux.org/packages/workcraft/). They will be useful when packaging for other distros though, hence why I'm adding them here.

Mime type is `application/x-workcraft`.
For Arch Linux (and probably Debian, Ubuntu and others), installation paths are:
`/usr/share/applications/workcraft.desktop`
`/usr/share/mime/packages/workcraft.xml`
The icon file should also be installed somewhere like:
`/usr/share/icons/hicolor/scalable/apps/workcraft.svg`